### PR TITLE
Simulated "false start" fix + default race change

### DIFF
--- a/lib/Simulator/Simulator.cpp
+++ b/lib/Simulator/Simulator.cpp
@@ -1,7 +1,7 @@
 // file:	Simulator.cpp
-// 
+//
 // summary:	Implements the simulator class. Since this class is memory intensive, it should only be
-// included if actual simulation is wished. 
+// included if actual simulation is wished.
 #include "Simulator.h"
 #include "config.h"
 #include "RaceHandler.h"
@@ -12,35 +12,64 @@
 ///   Program the interrupt triggers which should be simulated here. See end of file for a collection of records from actual races.
 /// </summary>
 const SimulatorClass::SimulatorRecord SimulatorClass::SimulatorQueue[60] PROGMEM = {
-   //See the end of this file for a collection of races
-   { 1,162901,1 },
-   { 2,190287,1 },
-   { 1,292299,0 },
-   { 1,308171,1 },
-   { 2,311576,0 },
-   { 1,315275,0 },
-   { 1,327828,1 },
-   { 1,331783,0 },
-   { 2,5216625,1 },
-   { 1,5233268,1 },
-   { 1,5240338,0 },
-   { 1,5242136,1 },
-   { 2,5362002,0 },
-   { 2,5367346,1 },
-   { 1,5468382,0 },
-   { 2,5488550,0 },
-   { 2,9910598,1 },
-   { 2,9915971,0 },
-   { 2,9919530,1 },
-   { 1,9923699,1 },
-   { 1,10092756,0 },
-   { 2,10112577,0 },
-   { 2,14495214,1 },
-   { 1,14509473,1 },
-   { 1,14511453,0 },
-   { 1,14515396,1 },
-   { 2,14627607,0 },
-   { 1,14641081,0 }
+    //See the end of this file for a collection of races
+    // Race3 (GT Team 4):
+    {1, -102316, 1},
+    {2, -87824, 1},
+    {2, -80456, 0},
+    {2, -78800, 1},
+    {1, 28952, 0},
+    {2, 44596, 0},
+    {2, 4364748, 1},
+    {2, 4366600, 0},
+    {2, 4368436, 1},
+    {1, 4380404, 1},
+    {1, 4382296, 0},
+    {1, 4384164, 1},
+    {2, 4489344, 0},
+    {1, 4505604, 0},
+    {1, 4730036, 1},
+    {2, 4744732, 1},
+    {1, 4857296, 0},
+    {2, 4872020, 0},
+    {2, 9344132, 1},
+    {1, 9361276, 1},
+    {1, 9552148, 0},
+    {2, 9575988, 0},
+    {2, 15477068, 1},
+    {1, 15494804, 1},
+    {1, 15549608, 0},
+    {1, 15563036, 1},
+    {2, 15580812, 0},
+    {1, 15594584, 0},
+    {1, 15610220, 1},
+    {1, 15613904, 0},
+    {1, 15909920, 1},
+    {2, 15925776, 1},
+    {1, 16042356, 0},
+    {2, 16060036, 0},
+    {2, 20674000, 1},
+    {1, 20690804, 1},
+    {2, 20795000, 0},
+    {1, 20803392, 0},
+    {1, 21335620, 1},
+    {2, 21355152, 1},
+    {2, 21469528, 0},
+    {2, 21473956, 1},
+    {1, 21497288, 0},
+    {2, 21521176, 0},
+    {2, 26444356, 1},
+    {1, 26461276, 1},
+    {2, 26582668, 0},
+    {1, 26600304, 0},
+    {1, 34022032, 1},
+    {2, 34130784, 1},
+    {2, 35350988, 0},
+    {2, 35720860, 1},
+    {2, 35731936, 0},
+    {2, 35768820, 1},
+    {2, 47982712, 0},
+    {1, 48095780, 0}
 
 };
 
@@ -83,18 +112,15 @@ void SimulatorClass::Main()
       //Pending record doesn't contain valid data, this means we've reched the end of our queue
       return;
    }
+   long lRaceElapsedTime = GET_MICROS - RaceHandler._lRaceStartTime;
    //Simulate sensors
-   if (RaceHandler.RaceState != RaceHandler.STOPPED
-      && PendingRecord.lTriggerTime <= (long) RaceHandler._lRaceTime)
+   if (RaceHandler.RaceState != RaceHandler.STOPPED && PendingRecord.lTriggerTime <= (long)lRaceElapsedTime)
    {
       if (RaceHandler._QueueEmpty())
       {
-         if ((PendingRecord.lTriggerTime < 0
-            && RaceHandler.RaceState == RaceHandler.STARTING)
-            || (PendingRecord.lTriggerTime > 0
-            && RaceHandler.RaceState == RaceHandler.RUNNING))
+         if ((PendingRecord.lTriggerTime < 0 && RaceHandler.RaceState == RaceHandler.STARTING) || (PendingRecord.lTriggerTime > 0 && RaceHandler.RaceState == RaceHandler.RUNNING))
          {
-            RaceHandler._QueuePush({ PendingRecord.iSensorNumber, (RaceHandler._lRaceStartTime + PendingRecord.lTriggerTime), PendingRecord.iState });
+            RaceHandler._QueuePush({PendingRecord.iSensorNumber, (RaceHandler._lRaceStartTime + PendingRecord.lTriggerTime), PendingRecord.iState});
             //And increase pending record
             _iDataPos++;
             PROGMEM_readAnything(&SimulatorQueue[_iDataPos], PendingRecord);
@@ -301,7 +327,6 @@ Race3 (GT Team 4):
    //Code has been implemented to filter these out.
    , { 2, 9370240, 1 }
    , { 2, 9373992, 0 }
-
    , { 2, 14112436, 1 }
    , { 1, 14127916, 1 }
    , { 2, 14233032, 0 }
@@ -450,4 +475,3 @@ Race3 (GT Team 4):
    {1,14641081,0}
 
 */
-

--- a/lib/Simulator/Simulator.cpp
+++ b/lib/Simulator/Simulator.cpp
@@ -118,7 +118,8 @@ void SimulatorClass::Main()
    {
       if (RaceHandler._QueueEmpty())
       {
-         if ((PendingRecord.lTriggerTime < 0 && RaceHandler.RaceState == RaceHandler.STARTING) || (PendingRecord.lTriggerTime > 0 && RaceHandler.RaceState == RaceHandler.RUNNING))
+         if ((PendingRecord.lTriggerTime < 0 && RaceHandler.RaceState == RaceHandler.STARTING)
+          || (PendingRecord.lTriggerTime > 0 && RaceHandler.RaceState == RaceHandler.RUNNING))
          {
             RaceHandler._QueuePush({PendingRecord.iSensorNumber, (RaceHandler._lRaceStartTime + PendingRecord.lTriggerTime), PendingRecord.iState});
             //And increase pending record

--- a/lib/WebHandler/WebHandler.cpp
+++ b/lib/WebHandler/WebHandler.cpp
@@ -13,7 +13,7 @@
 #include "GPSHandler.h"
 #include "BatterySensor.h"
 #include <rom/rtc.h>
-#include "..\..\src\static\index.html.gz.h"
+#include "../../src/static/index.html.gz.h"
 
 void WebHandlerClass::_WsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventType type, void *arg, uint8_t *data, size_t len)
 {

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,11 +22,6 @@ board = lolin32
 framework = arduino
 lib_ldf_mode = deep+
 monitor_speed = 115200
-upload_protocol = espota
-upload_port = 192.168.20.1
-upload_flags =
-    --host_ip=192.168.20.2
-    --auth=FlyballETS.1234
 
 # using the latest stable version
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,8 +25,8 @@ monitor_speed = 115200
 upload_protocol = espota
 upload_port = 192.168.20.1
 upload_flags =
-    --host_ip=192.168.20.2
     --auth=FlyballETS.1234
+;    --host_ip=192.168.20.2
 
 # using the latest stable version
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,11 @@ board = lolin32
 framework = arduino
 lib_ldf_mode = deep+
 monitor_speed = 115200
+upload_protocol = espota
+upload_port = 192.168.20.1
+upload_flags =
+    --host_ip=192.168.20.2
+    --auth=FlyballETS.1234
 
 # using the latest stable version
 lib_deps =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,7 +268,7 @@ void setup()
    ArduinoOTA.setPort(3232);
    ArduinoOTA.onStart([]() {
       String type;
-      if (ArduinoOTA.getCommand() == U_FLASH)
+      if (ArduinoOTA.getCommand() == 0) //VSCode constantly can't read properly value of U_FLASH, therefore replacing with "0"
          type = "sketch";
       else // U_SPIFFS
          type = "filesystem";


### PR DESCRIPTION
1. Fix (in fact restore from Arduino IDE version) for simulated "false start". Without that change simulated race with false starts of first dog doesn't work properly.
2. Also default race changed to Race 3 with nice demo/scenario that include "false start" and rerun of first dog.
3. some formatting / cosmetic changes made by "Prettier - Code formatter" extension of VSCode 